### PR TITLE
Enable heartbeats in Harp devices

### DIFF
--- a/src/Workflows/MainExperiment/Main.bonsai
+++ b/src/Workflows/MainExperiment/Main.bonsai
@@ -2946,7 +2946,7 @@
                 <harp:OperationLed>On</harp:OperationLed>
                 <harp:DumpRegisters>true</harp:DumpRegisters>
                 <harp:VisualIndicators>On</harp:VisualIndicators>
-                <harp:Heartbeat>Disabled</harp:Heartbeat>
+                <harp:Heartbeat>Enabled</harp:Heartbeat>
                 <harp:IgnoreErrors>false</harp:IgnoreErrors>
                 <harp:PortName>COM12</harp:PortName>
               </Combinator>
@@ -3361,7 +3361,7 @@
                 <harp:OperationLed>On</harp:OperationLed>
                 <harp:DumpRegisters>true</harp:DumpRegisters>
                 <harp:VisualIndicators>On</harp:VisualIndicators>
-                <harp:Heartbeat>Disabled</harp:Heartbeat>
+                <harp:Heartbeat>Enabled</harp:Heartbeat>
                 <harp:IgnoreErrors>false</harp:IgnoreErrors>
                 <harp:PortName>COM11</harp:PortName>
               </Combinator>

--- a/src/Workflows/MainExperiment/Main.bonsai.layout
+++ b/src/Workflows/MainExperiment/Main.bonsai.layout
@@ -262,8 +262,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -516,8 +516,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -636,8 +636,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>1466</Width>
-            <Height>758</Height>
+            <Width>1506</Width>
+            <Height>903</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -976,8 +976,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -1122,8 +1122,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -1412,8 +1412,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -1810,8 +1810,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -2568,8 +2568,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -3194,8 +3194,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1466</Width>
-        <Height>758</Height>
+        <Width>1506</Width>
+        <Height>903</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>


### PR DESCRIPTION
Relates to issue #106 

Heartbeats were disabled on H1/H2 previously. In this PR they are enabled to be used as a sanity check against timestamp discrepancies in issue #106 